### PR TITLE
Add AGPL-3.0 license and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,11 @@
+SPDX-License-Identifier: AGPL-3.0-only
+
+This project is licensed under the GNU Affero General Public License, version 3.0.
+
+You may obtain a copy of the full license text at:
+https://www.gnu.org/licenses/agpl-3.0.txt
+
+As required by the AGPL, if you modify and run this software over a
+network for users to interact with, you must make the Corresponding
+Source available to those users under the same license.
+

--- a/README.md
+++ b/README.md
@@ -62,4 +62,10 @@ export HF_HOME=./models/huggingface
 
 ## License
 
-MIT
+AGPL-3.0-only. See `LICENSE`.
+
+Third‑party components retain their own licenses:
+- Detector (Ultralytics/YOLO icon_detect): AGPL‑3.0 or commercial license
+- VLM (e.g., Qwen/Qwen2.5‑VL): Qwen Model License (Alibaba)
+- Decision model (e.g., openai/gpt‑oss‑20b): see model card/license
+- OCR (PaddleOCR/PaddlePaddle): Apache‑2.0


### PR DESCRIPTION
Added a LICENSE file specifying AGPL-3.0-only and updated the README to reflect the new license and clarify third-party component licenses.